### PR TITLE
Fix randomSound variable on Node 14

### DIFF
--- a/webserver.js
+++ b/webserver.js
@@ -30,7 +30,7 @@ io.on('connection', function (socket) {
       //console.log("change:" + value);
       state = "red";
       fs.readdir(dirPath + "/audio", function(err, files){
-        randomSound = files[Math.floor(Math.random() * files.length)];
+        let randomSound = files[Math.floor(Math.random() * files.length)];
         //console.log(randomSound);
         io.emit('change', 0, randomSound);
         socket.broadcast.emit('change', 0, randomSound);


### PR DESCRIPTION
randomSound variable was not defined, and it made doorbell to not ring. Adding definition of variable to fix that.

This PR is part of Hacktoberfest 2021. Requesting `hacktoberfest-accepted` label here.